### PR TITLE
Fixes to script after API update and for new events

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ We've also noticed discrepancies over time, i.e. the viewer counts don't seem to
 ### SMTP Server
 In the `send_email` function, we currently use [Gmail's Restricted SMTP Server](https://support.google.com/a/answer/176600?hl=en) to send email without having to provide any email login information, however this means the script can only send emails to Gmail or G Suite accounts. You can change these settings to your organization's SMTP server if you have one.
 
-### Social Media Events
-Streams to Facebook and YouTube do not have any analytics information, so we exclude events with `Social Media` in their name from the summary email. If your social media events are named something other than this, they won't be excluded and you'll get an empty analytics summary email for them.
+### Excluded Events
+Streams to Facebook and YouTube and test events do not generally have useful analytics information, so we exclude events with fewer than 5 viewers from the summary email. Their data will still be written to the JSON file.
 
 ### LA1 API Limits
 In one of the API requests we make to LA1, there is a `max=500` URL parameter. It's unclear whether that refers to the number of events returned or the number of detailed viewer analytics entries. If you have a large number of events or viewers, you should check to see that your data is not being truncated by this.

--- a/script.py
+++ b/script.py
@@ -61,6 +61,16 @@ Subject: {EMAIL_SUBJECT_PREFIX} [EVENT NAME WILL GO HERE]
     )
 
 
+def get_median_watch_time(event):
+    """Computes the median watch time based on LA1-provided mapping from
+    watch times to number of unique viewers.
+    NOTE: This data is only available at 5 minute granularities."""
+    times = []
+    for m, v in event['geodata']['watchTimes'].items():
+        times += [int(m)] * v
+    return times[len(times) // 2]
+
+
 def send_email(event):
     # This server is Gmail's Restricted SMTP Server and will only work for
     # sending emails to G Suite or Gmail accounts.
@@ -80,6 +90,9 @@ Average Watch Time (mins): {event['public_info']['averageViewMinutes']}
 Total Watch Time (mins): {event['public_info']['watchTimeMinutes']}
 Unique Viewers 30+ mins: {sum(v for m, v in event['geodata']['watchTimes'].items() if int(m) >= 30)}
 Unique Viewers 60+ mins: {sum(v for m, v in event['geodata']['watchTimes'].items() if int(m) >= 60)}
+
+Median Watch Time* (mins): {get_median_watch_time(event)}
+*Experimental (computed and not provided directly by LA1)
 """,
     )
 

--- a/script.py
+++ b/script.py
@@ -83,16 +83,20 @@ def send_email(event):
 To: {TO_EMAIL}
 Subject: {EMAIL_SUBJECT_PREFIX} {event['name']}
 
-Event Time:  {event['name']}, {event['start_time']}
+Event: {event['name']}, {event['start_time']}
+
 Unique Viewers: {event['public_info']['uniqueViewers']}
 Views: {event['public_info']['views']}
+
 Average Watch Time (mins): {event['public_info']['averageViewMinutes']}
 Total Watch Time (mins): {event['public_info']['watchTimeMinutes']}
-Unique Viewers 30+ mins: {sum(v for m, v in event['geodata']['watchTimes'].items() if int(m) >= 30)}
-Unique Viewers 60+ mins: {sum(v for m, v in event['geodata']['watchTimes'].items() if int(m) >= 60)}
-
 Median Watch Time* (mins): {get_median_watch_time(event)}
-*Experimental (computed and not provided directly by LA1)
+
+30+ minute views: {sum(v for m, v in event['geodata']['watchTimes'].items() if int(m) >= 30)}
+60+ minute views: {sum(v for m, v in event['geodata']['watchTimes'].items() if int(m) >= 60)}
+
+
+* Experimental statistic (not provided directly by LA1, computed by us)
 """,
     )
 


### PR DESCRIPTION
- LA1 switched to using APIv3, so this PR updates our fetching of "public_info" to that API. We also include some additional information like watch times that are now offered through that API.
- It looks like some events are now missing city or state info, so I've added a check so that the script doesn't crash from that as well.
- We have many events in Control from streaming, and this script would send a bunch of those emails with 0 viewers, so I've changed the logic to only send emails for events with "CHOP" in the name.